### PR TITLE
Add CI to build and publish Docker image

### DIFF
--- a/.github/workflows/docker-ci.yml
+++ b/.github/workflows/docker-ci.yml
@@ -1,0 +1,40 @@
+name: Docker CI
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - 'master'
+  pull_request:
+    branches:
+      - 'master'
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Log into Registry
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Get Metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            ghcr.io/${{ github.repository }}
+      - name: Build and Push Image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/docker-ci.yml
+++ b/.github/workflows/docker-ci.yml
@@ -30,8 +30,8 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           tags: |
-            type=edge
-            type=sha
+            type=raw,enable={{is_default_branch}},value=latest,priority=1000
+            type=sha,prefix=,format=long
           images: |
             ghcr.io/${{ github.repository }}
       - name: Build and Push Image

--- a/.github/workflows/docker-ci.yml
+++ b/.github/workflows/docker-ci.yml
@@ -18,11 +18,11 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Log into Registry
+      - name: Log into GitHub Registry
         if: github.event_name != 'pull_request'
         uses: docker/login-action@v3
         with:
-          registry: ${{ env.REGISTRY }}
+          registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Get Metadata

--- a/.github/workflows/docker-ci.yml
+++ b/.github/workflows/docker-ci.yml
@@ -29,6 +29,9 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
+          tags: |
+            type=edge
+            type=sha
           images: |
             ghcr.io/${{ github.repository }}
       - name: Build and Push Image


### PR DESCRIPTION
would be useful to have for compose files lol
felt like doing this because i was looking at docs

currently publishes to github's container registry, an example can be found here: [https://github.com/RoblKyogre/Crafting-Comrades-Website/pkgs/container/crafting-comrades-website](https://github.com/RoblKyogre/Crafting-Comrades-Website/pkgs/container/crafting-comrades-website)